### PR TITLE
[#1] Ensure that the certname is always lowercase

### DIFF
--- a/templates/install.ps1.erb
+++ b/templates/install.ps1.erb
@@ -16,11 +16,12 @@ function DownloadPuppet {
 
 function GetCertname {
   if (![string]::IsNullOrEmpty($certname)) {
-    $certname
+    $certname.ToLower()
   } else {
     $objIPProperties = [System.Net.NetworkInformation.IPGlobalProperties]::GetIPGlobalProperties()
     $name_components = @($objIPProperties.HostName, $objIPProperties.DomainName) | ? {$_}
     $name_components -Join "."
+    $name_components.ToLower()
   }
 }
 


### PR DESCRIPTION
This commit fixes issues #1 by making sure that the certname is always
lowercase.

In Puppet, certnames must be entirely lowercase. Previously, it was
possible for the certname to have uppercase characters. This fixes that.
