### PR TITLE
[#2] Only set the certname if requested

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 1. [Setup - Important!](#setup)
 1. [Usage](#usage)
   * [Windows Agent Install Process](#windows-agent-install-process)
-  * [Customizing Parameters](#customizing-parameters)
+  * [Customizing the install.ps1 script](#customizing-the-installps1-script)
 1. [Reference](#reference)
 1. [Limitations](#limitations)
 1. [Development](#development)
@@ -40,13 +40,13 @@ To execute the PowerShell-based installer on a Windows node, use one of the foll
 #### From an administrative Command Prompt window
 
 ```cmd
-@powershell -NoProfile -ExecutionPolicy unrestricted -Command "$webClient = New-Object System.Net.WebClient; $webClient.DownloadFile("https://pe-201532-master.puppetdebug.vlan:8140/packages/current/install.ps1", "$env:temp\install-agent.ps1
+@powershell -NoProfile -ExecutionPolicy unrestricted -Command "$webClient = New-Object System.Net.WebClient; $webClient.DownloadFile("https://<fqdn_of_puppet_master>:8140/packages/current/install.ps1", "$env:temp\install-agent.ps1
 ```
 
 #### From an administrative PowerShell window
 
 ```powershell
-$webClient = New-Object System.Net.WebClient; $webClient.DownloadFile("https://pe-201532-master.puppetdebug.vlan:8140/packages/current/install.ps1", "$env:temp\install-agent.ps1"); & "$env:temp\install-agent.ps1"
+$webClient = New-Object System.Net.WebClient; $webClient.DownloadFile("https://<fqdn_of_puppet_master>:8140/packages/current/install.ps1", "$env:temp\install-agent.ps1"); & "$env:temp\install-agent.ps1"
 ```
 
 **Note:** You must have your execution policy set to unrestricted (or at least in bypass) for this to work (`Set-ExecutionPolicy Unrestricted`).
@@ -55,8 +55,8 @@ $webClient = New-Object System.Net.WebClient; $webClient.DownloadFile("https://p
 
 The values for `server` and `certname`, in the agent's puppet.conf can be tuned during installation by passing the `server` and `certname` parameters to the `install.ps1` script.
 
-```
-$webClient = New-Object System.Net.WebClient; $webClient.DownloadFile("https://pe-201532-master.puppetdebug.vlan:8140/packages/current/install.ps1", "$env:temp\install-agent.ps1"); & "$env:temp\install-agent.ps1" -certname foo.custom.net -server puppet.custom.net
+```powershell
+$webClient = New-Object System.Net.WebClient; $webClient.DownloadFile("https://<fqdn_of_puppet_master>:8140/packages/current/install.ps1", "$env:temp\install-agent.ps1"); & "$env:temp\install-agent.ps1" -certname foo.custom.net -server puppet.custom.net
 ```
 
 ### Customizing the install.ps1 script
@@ -84,11 +84,6 @@ class { 'pe_install_ps1':
 
 #### `server_setting`
 The value that will go in the `server` setting in the agent's puppet.conf.
-
-Default value: `$::settings::server`
-
-#### `ca_setting`
-The value that will go in the `ca` setting in the agent's puppet.conf. If using load-balanced compile-masters, CA proxy'ing is on by default, so this setting will likely not need to be changed.
 
 Default value: `$::settings::server`
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "natemccurdy-pe_install_ps1",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "author": "natemccurdy",
   "summary": "Creates an install.ps1 script to automate puppet-agent installations in Puppet Entererprise",
   "license": "Apache-2.0",

--- a/templates/install.ps1.erb
+++ b/templates/install.ps1.erb
@@ -16,11 +16,12 @@ function DownloadPuppet {
 
 function GetCertname {
   if (![string]::IsNullOrEmpty($certname)) {
-    $certname
+    $certname.ToLower()
   } else {
     $objIPProperties = [System.Net.NetworkInformation.IPGlobalProperties]::GetIPGlobalProperties()
     $name_components = @($objIPProperties.HostName, $objIPProperties.DomainName) | ? {$_}
     $name_components -Join "."
+    $name_components.ToLower()
   }
 }
 

--- a/templates/install.ps1.erb
+++ b/templates/install.ps1.erb
@@ -14,28 +14,18 @@ function DownloadPuppet {
   $webclient.DownloadFile($msi_source,$msi_dest)
 }
 
-function GetCertname {
-  if (![string]::IsNullOrEmpty($certname)) {
-    $certname.ToLower()
-  } else {
-    $objIPProperties = [System.Net.NetworkInformation.IPGlobalProperties]::GetIPGlobalProperties()
-    $name_components = @($objIPProperties.HostName, $objIPProperties.DomainName) | ? {$_}
-    $name_components -Join "."
-    $name_components.ToLower()
-  }
-}
-
 function InstallPuppet {
-  $real_certname = GetCertname
-  if ([string]::IsNullOrWhiteSpace($real_certname)) {
-    Throw { "Unable to determine a certname to use. Halting installation" }
+  if (![string]::IsNullOrEmpty($certname)) {
+    $certname     = $certname.ToLower()
+    $certname_arg = "PUPPET_AGENT_CERTNAME=$certname"
+    Write-Host "Using certname => $certname"
   }
-  Write-Host "Using certname => $real_certname"
   Write-Host "Using server   => $server"
   Write-Host "Saving the install log to $install_log"
   Write-Host "Installing the Puppet Agent on $env:COMPUTERNAME..."
+
   $msiexec_path = "C:\Windows\System32\msiexec.exe"
-  $msiexec_args = "/qn /log $install_log /i $msi_dest PUPPET_MASTER_SERVER=$server PUPPET_AGENT_CERTNAME=$real_certname"
+  $msiexec_args = "/qn /log $install_log /i $msi_dest PUPPET_MASTER_SERVER=$server $certname_arg"
   $msiexec_proc = [System.Diagnostics.Process]::Start($msiexec_path, $msiexec_args)
   $msiexec_proc.WaitForExit()
 }


### PR DESCRIPTION
Prior to this, the certname value in puppet.conf was always being set by
the install.ps1 script. This is not needed because the puppet-agent MSI
will automatically determine an appropriate certname to use based on the
FQDN of the node.
