### PR TITLE
Added logic to run with default non-interactive mode by changing Writ…

### DIFF
--- a/templates/install.ps1.erb
+++ b/templates/install.ps1.erb
@@ -4,11 +4,14 @@ Param(
   [string]$certname    = $null,
   [string]$msi_dest    = "$env:temp\puppet-agent-x64.msi",
   [string]$msi_source  = "https://<%= @msi_host %>:8140/packages/current/windows-x86_64/puppet-agent-x64.msi",
-  [string]$install_log = "$env:temp\puppet-install.log"
+  [string]$install_log = "$env:temp\puppet-install.log",
+  [bool]$verbose       = $false
 )
 
 function DownloadPuppet {
-  Write-Host "Downloading the Puppet Agent for Puppet Enterprise <%= @pe_build %> on $env:COMPUTERNAME..."
+  if ($verbose -ne $false) {
+    Write-Verbose "Downloading the Puppet Agent for Puppet Enterprise <%= @pe_build %> on $env:COMPUTERNAME..." -verbose
+  }
   [System.Net.ServicePointManager]::ServerCertificateValidationCallback={$true}
   $webclient = New-Object system.net.webclient
   $webclient.DownloadFile($msi_source,$msi_dest)
@@ -30,10 +33,12 @@ function InstallPuppet {
   if ([string]::IsNullOrEmpty($real_certname)) {
     Throw { "Unable to determine a certname to use. Halting installation" }
   }
-  Write-Host "Using certname => $real_certname"
-  Write-Host "Using server   => $server"
-  Write-Host "Saving the install log to $install_log"
-  Write-Host "Installing the Puppet Agent on $env:COMPUTERNAME..."
+  if ($verbose -ne $false) {
+    Write-Verbose "Using certname => $real_certname" -verbose
+    Write-Verbose "Using server   => $server" -verbose
+    Write-Verbose "Saving the install log to $install_log" -verbose
+    Write-Verbose "Installing the Puppet Agent on $env:COMPUTERNAME..." -verbose
+  }
   $msiexec_path = "C:\Windows\System32\msiexec.exe"
   $msiexec_args = "/qn /log $install_log /i $msi_dest PUPPET_MASTER_SERVER=$server PUPPET_AGENT_CERTNAME=$real_certname"
   $msiexec_proc = [System.Diagnostics.Process]::Start($msiexec_path, $msiexec_args)
@@ -42,7 +47,9 @@ function InstallPuppet {
 
 function ValidateInstall {
   If ((Get-WmiObject -Class Win32_Product).Name -match 'Puppet') {
-    Write-Host "The Puppet Agent has been installed on $env:COMPUTERNAME"
+    If ($verbose -ne $false) {
+      Write-Verbose "The Puppet Agent has been installed on $env:COMPUTERNAME" -verbose
+    }
   } else {
     Throw {
       "Something went wrong with the installation on $env:COMPUTERNAME.  Check the install log at: $install_log"
@@ -54,4 +61,6 @@ DownloadPuppet
 InstallPuppet
 ValidateInstall
 
-Write-Host "Installation has completed."
+if ($verbose -ne $false) {
+  Write-Verbose "Installation has completed." -verbose
+}


### PR DESCRIPTION
Added logic to run with default non-interactive mode by changing Write-Host to Write-Verbose. To enable writing output to console, pass -verbose  flag. Updated README with this information. Reason for change was attempting to run this through a non-interactive powershell process like from Cisco UCS Director.
